### PR TITLE
Update to 1.19.x

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,5 @@
 # Done to increase the memory available to gradle.
 org.gradle.jvmargs=-Xmx2G
-org.gradle.java.home=C:/Program Files/Microsoft/jdk-17.0.1.12-hotspot
 
 # Fabric Properties
 	# check these on https://fabricmc.net/versions.html

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -22,7 +22,7 @@
   "depends": {
     "fabricloader": ">=0.11.3",
     "fabric": "*",
-    "minecraft": "1.19",
+    "minecraft": "1.19.x",
     "java": ">=17"
   }
 }

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -22,7 +22,7 @@
   "depends": {
     "fabricloader": ">=0.11.3",
     "fabric": "*",
-    "minecraft": "1.18.x",
+    "minecraft": "1.19",
     "java": ">=17"
   }
 }


### PR DESCRIPTION
Also removes `org.gradle.java.home` to defer to the default Java path for greater compatibility.